### PR TITLE
UGC-4068 | Change getFilePath method

### DIFF
--- a/classes/media/FFProbe.php
+++ b/classes/media/FFProbe.php
@@ -11,6 +11,8 @@
 
 namespace EmbedVideo;
 
+use FSFile;
+
 class FFProbe {
 	/**
 	 * MediaWiki File
@@ -116,6 +118,10 @@ class FFProbe {
 	}
 
 	private function getFilePath() {
+		if ( $this->file instanceof FSFile ) {
+			return $this->file->getPath();
+		}
+
 		return $this->file->getLocalRefPath();
 	}
 


### PR DESCRIPTION
Changed getFilePath method to work when file is FSFile class (it happens when uploading video).