### PR TITLE
UGC-4293 | Fix Nico Nico Video embeds

### DIFF
--- a/classes/VideoService.php
+++ b/classes/VideoService.php
@@ -234,7 +234,7 @@ class VideoService {
 			]
 		],
 		'nico' => [
-			'embed'			=> '<iframe title="%4$s" allowfullscreen="allowfullscreen" frameborder="0" width="%2$d" height="%3$d" src="https://embed.nicovideo.jp/watch/%1$s?oldScript=1&amp;allowProgrammaticFullScreen=1" style="max-width: 100%;"></iframe>',
+			'embed'			=> '<iframe title="%4$s" allowfullscreen="allowfullscreen" frameborder="0" width="%2$d" height="%3$d" src="https://embed.nicovideo.jp/watch/%1$s?oldScript=1&amp;allowProgrammaticFullScreen=1" style="max-width: 100%%;"></iframe>',
 			'default_width'	=> 640,
 			'default_ratio'	=> 1.59609120521173, // (490 / 307)
 			'https_enabled'	=> false,


### PR DESCRIPTION
Nico Nico video embed link has used a single `%` sign to set `max-width` style and it was passed to sprintf function which is a specifier character and wasn't escaped.