### PR TITLE
Fix string interpolation

### DIFF
--- a/EmbedVideo.hooks.php
+++ b/EmbedVideo.hooks.php
@@ -326,7 +326,7 @@ class EmbedVideoHooks implements ParserFirstCallInitHook {
 				$parser,
 				$args['service'],
 				$args['defaultid'],
-				"${w}x${h}",
+				"{$w}x{$h}",
 				$args['alignment'],
 				$args['description'],
 				$args['container'],


### PR DESCRIPTION
PHP 8.2 deprecates ${var} for string interpolation, so don't use it.