### PR TITLE
Fix various PHP notices and warnings

### DIFF
--- a/classes/VideoService.php
+++ b/classes/VideoService.php
@@ -917,7 +917,9 @@ class VideoService {
 
 		if (is_array($_args)) {
 			foreach ($_args as $rawPair) {
-				list($key, $value) = explode("=", $rawPair, 2);
+				$parts = explode("=", $rawPair, 2);
+				$key = $parts[0];
+				$value = $parts[1] ?? null;
 				if (empty($key) || ($value === null || $value === '')) {
 					return false;
 				}
@@ -957,6 +959,7 @@ class VideoService {
 	 * @return mixed	Integer ratio or false if not set.
 	 */
 	public function getDefaultRatio() {
-		return ($this->service['default_ratio'] > 0 ? $this->service['default_ratio'] : false);
+		$defaultRatio = $this->service['default_ratio'] ?? 0;
+		return $defaultRatio > 0 ? $defaultRatio : false;
 	}
 }

--- a/classes/media/AudioHandler.php
+++ b/classes/media/AudioHandler.php
@@ -65,7 +65,7 @@ class AudioHandler extends \MediaHandler {
 		$magnitude = [1, 60, 3600, 86400];
 		$seconds = 0;
 		foreach ($parts as $index => $part) {
-			$seconds += $part * $magnitude[$index];
+			$seconds += (float)$part * $magnitude[$index];
 		}
 		return $seconds;
 	}

--- a/classes/media/AudioTransformOutput.php
+++ b/classes/media/AudioTransformOutput.php
@@ -94,7 +94,15 @@ class AudioTransformOutput extends \MediaTransformOutput {
 			}
 		}
 
-		$descLink = Html::element( 'a', [ 'href' => $parameters['descriptionUrl'] ], $parameters['descriptionUrl'] );
+		if ( isset( $parameters['descriptionUrl'] ) ) {
+			$descLink = Html::element(
+				'a',
+				[ 'href' => $parameters['descriptionUrl'] ],
+				$parameters['descriptionUrl']
+			);
+		} else {
+			$descLink = '';
+		}
 
 		return Html::rawElement( 'audio', [
 			'src' => $this->url . ($inOut !== false ? '#t=' . implode(',', $inOut) : ''),

--- a/classes/media/FFProbe.php
+++ b/classes/media/FFProbe.php
@@ -169,8 +169,8 @@ class FFProbe {
 
 		if ( is_array( $result ) ) {
 			$this->metadata = [
-				'streams' => $result['streams'],
-				'format' => $result['format'],
+				'streams' => $result['streams'] ?? null,
+				'format' => $result['format'] ?? null,
 			];
 
 			return true;

--- a/classes/media/VideoTransformOutput.php
+++ b/classes/media/VideoTransformOutput.php
@@ -92,7 +92,15 @@ class VideoTransformOutput extends \MediaTransformOutput {
 			}
 		}
 
-		$descLink = Html::element( 'a', [ 'href' => $parameters['descriptionUrl'] ], $parameters['descriptionUrl'] );
+		if ( isset( $parameters['descriptionUrl'] ) ) {
+			$descLink = Html::element(
+				'a',
+				[ 'href' => $parameters['descriptionUrl'] ],
+				$parameters['descriptionUrl']
+			);
+		} else {
+			$descLink = '';
+		}
 
 		return Html::rawElement( 'video', [
 			'src' => $this->url . ($inOut !== false ? '#t=' . implode(',', $inOut) : ''),


### PR DESCRIPTION
EmbedVideo is one of the most prolific polluters of our logs. Anybody attempting to investigate an issue must first filter away all the garbage it generates.

So, fix all warnings and notices emitted by the extension over the last 7 days:
* PHP Warning: Undefined array key "format" in /extensions/EmbedVideo/classes/media/FFProbe.php on line 173
* PHP Warning: Undefined array key "streams" in /extensions/EmbedVideo/classes/media/FFProbe.php on line 172
* PHP Warning: Undefined array key "descriptionUrl" in /extensions/EmbedVideo/classes/media/VideoTransformOutput.php on line 95
* PHP Warning: Undefined array key "descriptionUrl" in /extensions/EmbedVideo/classes/media/AudioTransformOutput.php on line 97
* PHP Warning: Undefined array key "default_ratio" in /extensions/EmbedVideo/classes/VideoService.php on line 960
* PHP Warning: A non-numeric value encountered in /extensions/EmbedVideo/classes/media/AudioHandler.php on line 68
* TypeError from line 68 of /extensions/EmbedVideo/classes/media/AudioHandler.php: Unsupported operand types: string * int
* PHP Warning: Undefined array key 1 in /extensions/EmbedVideo/classes/VideoService.php on line 920